### PR TITLE
Bug fix: Correct number of Outputs for an LEM03 from 16 to 8

### DIFF
--- a/alarm.js
+++ b/alarm.js
@@ -1516,7 +1516,7 @@ function ComfortConfiguration(filename) {
         var lem = comfortjs.Configuration.Modules[0].$.LEM03 == "true";
 
         if (lem) {
-            return 16;
+            return 8;
         } else {
             return 16 + (16 * slaves);
         }


### PR DESCRIPTION
Alarm.js Bug fix: Correct the number of Maximum Outputs for an LEM03 from 16 to 8.  The number of Maximum Inputs for an LEM03 are correct at 24.